### PR TITLE
Add command line interface (CLI), and install intxeger command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ print(x.sample(N=2))
 # ['11:57:12 AM', '01:16:01 AM']
 ```
 
+You can also print matches on the command line.
+
+```console
+$ intxeger --order=desc "[a-c]"
+c
+b
+a
+$ python3 -m intxeger -0 'base/[ab]/[12]' | xargs -0 mkdir -p
+$ tree base/
+base
+├── a
+│   ├── 1
+│   └── 2
+└── b
+    ├── 1
+    └── 2
+```
+
 To learn more about the functionality provided by `IntXeger`, check out our 
 [documentation](https://k15z.github.io/IntXeger)!
 

--- a/intxeger/__main__.py
+++ b/intxeger/__main__.py
@@ -1,0 +1,83 @@
+"""
+Print strings that can match a regular expression
+"""
+import argparse
+import re
+import sys
+
+import intxeger
+
+
+def check_pattern(s):
+    try:
+        re.compile(s)
+    except re.error as exc:
+        raise argparse.ArgumentTypeError(exc)
+    return s
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(
+        prog="python -m intxeger" if sys.argv[0].endswith("__main__.py") else None,
+        description=__doc__,
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "regex",
+        type=check_pattern,
+        help="A regular expression.",
+    )
+    parser.add_argument(
+        "--max-repeat",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Maximum repetitions for '.' & '*' operators (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--order",
+        choices=("asc", "desc", "random"),
+        default="asc",
+        help="Order in which to print expansions (default: %(default)s)",
+    )
+    terminators = parser.add_mutually_exclusive_group()
+    terminators.add_argument(
+        "--terminator",
+        "-t",
+        default="\n",
+        metavar="STR",
+        help="Terminate each expansion with string STR (default: %(default)r)",
+    )
+    terminators.add_argument(
+        "-0",
+        action="store_const",
+        const="\0",
+        dest="terminator",
+        help="Terminate each expansion with a NUL character",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=intxeger.__version__,
+    )
+    args = parser.parse_args(args)
+
+    regex = args.regex + re.escape(args.terminator)
+    root_node = intxeger.build(regex, max_repeat=args.max_repeat)
+
+    if args.order == "asc":
+        iterator = root_node.iterator(ordered=True)
+    elif args.order == "desc":
+        iterator = (root_node[i] for i in range(root_node.length - 1, -1, -1))
+    elif args.order == "random":
+        iterator = root_node.iterator(ordered=False)
+
+    for match in iterator:
+        sys.stdout.write(match)
+    sys.stdout.flush()
+
+    raise SystemExit(0)
+
+
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,11 @@ setup(
     keywords="intxeger",
     name="intxeger",
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*"]),
+    entry_points={
+        'console_scripts': [
+            'intxeger=intxeger.__main__:main',
+        ],
+    },
     python_requires=">=3.6",
     test_suite="intxeger/tests",
     tests_require=test_requirements,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,148 @@
+"""Test command module and argument handling."""
+import pytest
+
+from intxeger.__main__ import main
+from intxeger import __version__
+
+
+def test_expand_with_defaults(capsys):
+    """Test that by default one expansion is printed per line."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['[a-c]'])
+    capture = capsys.readouterr()
+    assert capture.out == "a\nb\nc\n"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_space_terminator(capsys):
+    """Test that expansions can be space terminated."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-t', ' ', '[a-c]'])
+    capture = capsys.readouterr()
+    assert capture.out == "a b c "
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_empty_terminators(capsys):
+    """Test that expansions can be terminated by an empty string."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-t', '', '[a-c]'])
+    capture = capsys.readouterr()
+    assert capture.out == "abc"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_with_nul_terminators(capsys):
+    """Test that expansions can be terminated by a NUL character."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-0', '[a-c]'])
+    capture = capsys.readouterr()
+    assert capture.out == "a\x00b\x00c\x00"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_ascending(capsys):
+    """Test that expansions can be output sorted."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['--order', 'asc', '[a-c]'])
+    capture = capsys.readouterr()
+    assert capture.out == "a\nb\nc\n"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_descending(capsys):
+    """Test that expansions can be output sorted, highest to lowest."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['--order', 'desc', '[a-c]'])
+    capture = capsys.readouterr()
+    assert capture.out == "c\nb\na\n"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_expand_random_order(capsys):
+    """Test that expansions can be output in a random order"""
+    with pytest.raises(SystemExit) as exinfo1:
+        main(['--order', 'random', '[a-z]'])
+    capture1 = capsys.readouterr()
+    assert capture1.err == ""
+    assert exinfo1.value.code == 0
+
+    with pytest.raises(SystemExit) as exinfo2:
+        main(['--order', 'random', '[a-z]'])
+    capture2 = capsys.readouterr()
+    assert capture2.err == ""
+    assert exinfo2.value.code == 0
+
+    # Probability p of 2 randomly selected outputs matching is
+    #   p = 1 - ((N-1) / N)         -- N = number of possible outputs
+    #     = 1 - ((26!-1) / 26!)     -- [a-z] -> N = factorial(26) = 26!
+    #     = 2.48 × 10^-27           -- essentially 0
+    # https://preshing.com/20110504/hash-collision-probabilities/
+    assert capture1.out != capture2.out
+    assert sorted(capture1.out.split()) == sorted(capture2.out.split())
+
+
+def test_terminator_arguments_are_mutually_exclusive(capsys):
+    """Test that contradicting terminators raise an error."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['-0', '--terminator', ' ', '[a-c]'])
+
+    capture = capsys.readouterr()
+    assert capture.out == ""
+    assert capture.err.find("error: argument --terminator/-t: not allowed with argument -0") > 0
+    assert exinfo.value.code > 0
+
+
+def test_help(capsys):
+    """Test that help is available."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['--help'])
+    capture = capsys.readouterr()
+    assert capture.out.startswith("usage:")
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_version(capsys):
+    """Test that the version is available."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['--version'])
+    capture = capsys.readouterr()
+    assert capture.out == f"{__version__}\n"
+    assert capture.err == ""
+    assert exinfo.value.code == 0
+
+
+def test_no_args_errors(capsys):
+    """Test that an error is reported when no expression is provided."""
+    with pytest.raises(SystemExit) as exinfo:
+        main([])
+    capture = capsys.readouterr()
+    assert capture.out == ""
+    assert capture.err.endswith("error: the following arguments are required: regex\n")
+    assert exinfo.value.code > 0
+
+
+def test_excess_args_errors(capsys):
+    """Test that an error is reported when too many arguments are provided."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['[a-c]', '[1-3]'])
+    capture = capsys.readouterr()
+    assert capture.out == ""
+    assert capture.err.find("error: unrecognized arguments") > 0
+    assert exinfo.value.code > 0
+
+def test_invalid_regex_errors(capsys):
+    """Test that an error is reported when the regex cannot be parsed."""
+    with pytest.raises(SystemExit) as exinfo:
+        main(['[a-c'])
+    capture = capsys.readouterr()
+    assert capture.out == ""
+    assert capture.err.find("error: argument regex: unterminated character set at position 0") > 0
+    assert exinfo.value.code > 0


### PR DESCRIPTION
E.g.

```
$ python3 -m intxeger --order=desc -t' ' '[a-z]' ; echo
z y x w v u t s r q p o n m l k j i h g f e d c b a
```
```
$ intxeger --help
usage: intxeger [-h] [--max-repeat N] [--order {asc,desc,random}]
                [--terminator STR | -0] [--version] regex

Print strings that can match a regular expression

positional arguments:
  regex                 A regular expression.

optional arguments:
  -h, --help            show this help message and exit
  --max-repeat N        Maximum repetitions for '.' & '*'
                        operators (default: 10)
  --order {asc,desc,random}
                        Order in which to print expansions
                        (default: asc)
  --terminator STR, -t STR
                        Terminate each expansion with string STR
                        (default: '\n')
  -0                    Terminate each expansion with a NUL character
  --version             show program's version number and exit
```