### PR TITLE
Add Python 3.10 tests, and declare support

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install Dependencies

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.python-version}}
     - name: Install Dependencies
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install Dependencies

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.python-version}}
     - name: Install Dependencies
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install Dependencies

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     description="Generate unique strings from regular expressions.",
     install_requires=requirements,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,12 @@
 [tox]
 skipsdist = True
-envlist = py37, py38, lint
+envlist =
+    py36,
+    py37,
+    py38,
+    py39,
+    py310,
+    lint,
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Python 3.10 was released recently, this adds test coverage and declares support on PyPI.

I also took the liberty of match Tox coverage with Github actions.